### PR TITLE
fix broken dependency, more color rules

### DIFF
--- a/interceptors/console-colorizer/src/main/jflex/OutputLexer.flex
+++ b/interceptors/console-colorizer/src/main/jflex/OutputLexer.flex
@@ -44,6 +44,9 @@ WhiteSpace     = {LineTerminator} | [ \t\f]
 <YYINITIAL> .*"<<< FAILURE!"      { print(RED, yytext(), BOLD);  }
 
 <YYINITIAL> ^"[ERROR]" { term.fg(RED); out.print(yytext()); yybegin(LOGLINE); }
+<YYINITIAL> \t"at" { term.fg(RED); out.print(yytext()); yybegin(LOGLINE); }
+<YYINITIAL> \t"..." { term.fg(RED); out.print(yytext()); yybegin(LOGLINE); }
+<YYINITIAL> ^"Caused by:" { term.fg(RED); out.print(yytext()); yybegin(LOGLINE); }
 <YYINITIAL> ^"[DEBUG]" { term.fg(WHITE); out.print(yytext()); yybegin(LOGLINE); }
 <YYINITIAL> ^"[WARNING]" { term.fg(YELLOW); out.print(yytext()); yybegin(LOGLINE); }
 <YYINITIAL> ^"[INFO]" { out.print(yytext()); yybegin(LOGLINE); }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <extension>
                 <groupId>org.jvnet.wagon-svn</groupId>
                 <artifactId>wagon-svn</artifactId>
-                <version>1.8</version>
+                <version>1.9</version>
             </extension>
         </extensions>
         <plugins>


### PR DESCRIPTION
I fixed a broken dependency and added more color rules for stack traces.

Also, what's the best way to do a multi-line match? I want to add a color rule that colors a line red if the next line starts with \t"at".
