### PR TITLE
fix the error of 'Could not find artifact ... and parent.relativePath points at wrong local POM' in maven 3.0.4

### DIFF
--- a/interceptors/always-offline/pom.xml
+++ b/interceptors/always-offline/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>always-offline</artifactId>

--- a/interceptors/console-colorizer/pom.xml
+++ b/interceptors/console-colorizer/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>console-colorizer</artifactId>

--- a/interceptors/pom.xml
+++ b/interceptors/pom.xml
@@ -4,6 +4,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>maven-interceptor-parent</artifactId>

--- a/interceptors/yamlpom/pom.xml
+++ b/interceptors/yamlpom/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>yamlpom</artifactId>

--- a/maven-interceptor-framework/pom.xml
+++ b/maven-interceptor-framework/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>maven-interceptor-framework</artifactId>

--- a/maven-trap/pom.xml
+++ b/maven-trap/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.twdata.maven.trap</groupId>
         <artifactId>maven-trap-parent</artifactId>
         <version>0.6-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>maven-trap</artifactId>


### PR DESCRIPTION
repro steps:
1. use latest maven (3.0.4)
2. rm -rf ~/.m2/repository/org/twdata
3. mvn clean install
